### PR TITLE
Feat : PO-17 새로운 포스트 모달 구현

### DIFF
--- a/src/api/post/postNewPost.ts
+++ b/src/api/post/postNewPost.ts
@@ -1,27 +1,24 @@
 import { axiosInstance } from "api/token/axiosInstance";
-export interface RegisterData {
-  email: string;
-  name: string;
-  nickname: string;
-  password: string;
-}
+import INewPost from "interface/post/INewPost";
+import { toast } from "react-toastify";
 
-export interface RegisterDTO {
-  data: RegisterData;
-}
-
-const postRegister = async (inputData: RegisterDTO) => {
+const postNewPost = async (postDetails: INewPost) => {
   try {
-    const API_URL = "/api/member/register";
+    const API_URL = "/api/post/write";
 
-    const response = await axiosInstance.post(API_URL, inputData);
+    // 여기에서 post 메서드에 URL과 데이터를 별도의 인자로 전달합니다.
+    const response = await axiosInstance.post(API_URL, { data: postDetails });
 
     const code = response.status;
-
+    if (code === 200) {
+      toast.info("업로드 성공");
+    }
     return code;
   } catch (error) {
+    console.log("post에 실패했습니다.");
+    console.error(error);
     return null;
   }
 };
 
-export default postRegister;
+export default postNewPost;

--- a/src/api/post/postNewPost.ts
+++ b/src/api/post/postNewPost.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from "api/token/axiosInstance";
+export interface RegisterData {
+  email: string;
+  name: string;
+  nickname: string;
+  password: string;
+}
+
+export interface RegisterDTO {
+  data: RegisterData;
+}
+
+const postRegister = async (inputData: RegisterDTO) => {
+  try {
+    const API_URL = "/api/member/register";
+
+    const response = await axiosInstance.post(API_URL, inputData);
+
+    const code = response.status;
+
+    return code;
+  } catch (error) {
+    return null;
+  }
+};
+
+export default postRegister;

--- a/src/components/button/user/UserActionBtn.tsx
+++ b/src/components/button/user/UserActionBtn.tsx
@@ -2,6 +2,9 @@ import { ReactJSXElement } from "@emotion/react/types/jsx-namespace";
 import btnStyle from "./UserActionBtn.module.css";
 import ModalOption from "../../../enum/modalOptionTypes";
 import { useModal } from "../../../hooks/modal/ModalProvider";
+import secureLocalStorage from "react-secure-storage";
+import { toast } from "react-toastify";
+
 interface userActionBtnProps {
   name: string;
   icon: ReactJSXElement;
@@ -10,9 +13,11 @@ interface userActionBtnProps {
 function UserActionBtn({ name, icon, type }: userActionBtnProps) {
   const { openModal } = useModal();
   const handleModal = () => {
-    openModal(type);
-    console.log("open modal");
-    console.log(type);
+    if (secureLocalStorage.getItem("accessToken")) {
+      openModal(type);
+    } else {
+      toast.error("로그인이 필요한 기능입니다.");
+    }
   };
   return (
     <button className={btnStyle.btn} onClick={handleModal}>

--- a/src/components/form/card/CardForm.module.css
+++ b/src/components/form/card/CardForm.module.css
@@ -17,7 +17,7 @@
   font-size: 1.2rem;
   font-weight: bold;
   color: var(--main-theme-color);
-  padding: 5px 8px;
+  padding: 3px 8px;
   border-radius: 8px;
   transition: all 0.1s ease-in-out;
 }
@@ -42,6 +42,10 @@
   width: 100%;
   height: 100%;
   display: inline-block;
+  overflow: hidden; /* 래퍼 크기를 넘어가는 이미지 부분을 숨김 */
+  display: flex; /* 이미지를 중앙 정렬하기 위해 flex 사용 */
+  justify-content: center; /* 가로 중앙 정렬 */
+  align-items: center; /* 세로 중앙 정렬 */
 }
 
 .previewImg {
@@ -84,7 +88,7 @@
 .cardFormWrapper {
   box-sizing: border-box;
   flex-shrink: 0;
-  width: 600px;
+  width: 750px;
   padding: 10px;
   overflow-y: hidden;
   max-height: 400px;
@@ -111,6 +115,11 @@
   padding: 0;
 }
 
+.mapAction {
+  display: flex;
+  flex-direction: row;
+}
+
 .locationAction {
   display: flex;
   flex-direction: row;
@@ -132,4 +141,5 @@
   border-radius: 8px;
   background-color: var(--main-theme-color);
   color: white;
+  margin: 0;
 }

--- a/src/components/form/card/CardForm.module.css
+++ b/src/components/form/card/CardForm.module.css
@@ -42,6 +42,12 @@
   height: 100%;
 }
 
+.previewImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .cardFormWrapper {
   box-sizing: border-box;
   flex-shrink: 0;
@@ -59,7 +65,6 @@
   display: flex;
   flex-direction: column;
   justify-items: flex-start;
-  transition: all 0.5s ease-in-out;
   grid-gap: 10px;
 }
 

--- a/src/components/form/card/CardForm.module.css
+++ b/src/components/form/card/CardForm.module.css
@@ -48,6 +48,21 @@
   object-fit: cover;
 }
 
+.deleteBtn {
+  position: absolute;
+  size: 24px;
+  top: 10px;
+  left: 260px;
+  color: tomato; /* 텍스트 색상, 필요에 따라 조정 */
+  border: none;
+  cursor: pointer;
+}
+
+.deleteBtn:hover {
+  transform: scale(1.2);
+  transition: transform 0.2s ease-in-out;
+}
+
 .cardFormWrapper {
   box-sizing: border-box;
   flex-shrink: 0;

--- a/src/components/form/card/CardForm.module.css
+++ b/src/components/form/card/CardForm.module.css
@@ -38,21 +38,21 @@
   transition: all 0.1s ease-in-out;
 }
 .previewWrapper {
+  position: relative;
   width: 100%;
   height: 100%;
+  display: inline-block;
 }
 
 .previewImg {
   width: 100%;
   height: 100%;
+  display: block;
   object-fit: cover;
 }
 
 .deleteBtn {
-  position: absolute;
   size: 24px;
-  top: 10px;
-  left: 260px;
   color: tomato; /* 텍스트 색상, 필요에 따라 조정 */
   border: none;
   cursor: pointer;
@@ -61,6 +61,24 @@
 .deleteBtn:hover {
   transform: scale(1.2);
   transition: transform 0.2s ease-in-out;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  opacity: 0; /* 기본적으로 오버레이를 숨깁니다. */
+  background-color: rgba(0, 0, 0, 0.1); /* 오버레이 배경 색상 및 투명도 */
+  transition: opacity 0.2s ease; /* 부드러운 표시/숨김 효과 */
+}
+
+.previewWrapper:hover .overlay {
+  opacity: 1;
 }
 
 .cardFormWrapper {

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -10,6 +10,7 @@ import useBucket from "hooks/bucket/useBucket";
 import { RootState } from "redux/store/store";
 import { IUploadImage } from "interface/bucket/IUploadImage";
 import { toast } from "react-toastify";
+import { IoMdCloseCircle } from "react-icons/io";
 
 declare global {
   interface Window {
@@ -28,9 +29,10 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
     handleImageChange,
     handleContentsChange,
     handlePlaceChange,
+    handleImageRemove,
   } = useSingleCard(cardDetails);
   // 이미지 업로딩 관련 const
-  const { uploadImage } = useBucket();
+  const { uploadImage, deleteImage } = useBucket();
   const postId = useSelector((state: RootState) => state.newPost.postId);
   // 리덕스 관련
   const dispatch = useDispatch();
@@ -82,6 +84,11 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
     }
   };
 
+  const handleDeleteImg = () => {
+    deleteImage(`${process.env.REACT_APP_BUCKET_BASEURL}/${newCard.image}`);
+    handleImageRemove();
+  };
+
   useEffect(() => {
     if (isMapVisible && mapContainer.current) {
       initKakaoMap(mapContainer.current);
@@ -124,6 +131,11 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
         </div>
       ) : (
         <div className={formStyles.previewWrapper}>
+          <IoMdCloseCircle
+            className={formStyles.deleteBtn}
+            size={"20px"}
+            onClick={handleDeleteImg}
+          />
           <img
             alt="Preview"
             className={formStyles.previewImg}

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -119,6 +119,7 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
             accept="image/*"
             onChange={handleImageUpload}
             style={{ display: "none" }}
+            required
           />
         </div>
       ) : (

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -172,8 +172,10 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
               value={searchPlace}
               onKeyDown={handleSearch}
             />
-            <div>
-              <button className={formStyles.uploadBtn}>현재위치</button>
+            <div className={formStyles.mapAction}>
+              <button className={formStyles.uploadBtn} onClick={handleSearch}>
+                검색
+              </button>
               <button
                 className={formStyles.mapToggleBtn}
                 onClick={toggleMapVisibility}

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -126,6 +126,7 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
         <div className={formStyles.previewWrapper}>
           <img
             alt="Preview"
+            className={formStyles.previewImg}
             src={`${process.env.REACT_APP_BUCKET_BASEURL}/${newCard.image}`}
             width="100%"
             height="100%"
@@ -180,7 +181,6 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
               width: "370px",
               height: "200px",
               overflow: "hidden", // 내용이 넘칠 경우 숨김 처리
-              transition: "all 0.5s ease", // 부드러운 전환 효과
             }}
           />
         </div>

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -131,11 +131,6 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
         </div>
       ) : (
         <div className={formStyles.previewWrapper}>
-          <IoMdCloseCircle
-            className={formStyles.deleteBtn}
-            size={"20px"}
-            onClick={handleDeleteImg}
-          />
           <img
             alt="Preview"
             className={formStyles.previewImg}
@@ -143,6 +138,13 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
             width="100%"
             height="100%"
           />
+          <div className={formStyles.overlay}>
+            <IoMdCloseCircle
+              className={formStyles.deleteBtn}
+              size={"20px"}
+              onClick={handleDeleteImg}
+            />
+          </div>
         </div>
       )}
       {

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -101,7 +101,7 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
 
   return (
     <div className={formStyles.cardFormWrapper}>
-      {!newCard.imageUrl ? (
+      {!newCard.image ? (
         <div className={formStyles.imageWrapper}>
           <img
             src="./icons/photo/postPhoto.png"
@@ -126,7 +126,7 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
         <div className={formStyles.previewWrapper}>
           <img
             alt="Preview"
-            src={`${process.env.REACT_APP_BUCKET_BASEURL}/${newCard.imageUrl}`}
+            src={`${process.env.REACT_APP_BUCKET_BASEURL}/${newCard.image}`}
             width="100%"
             height="100%"
           />
@@ -136,9 +136,9 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
         <div
           className={formStyles.detailWrapper}
           style={{
-            width: newCard.imageUrl ? "100%" : "0px",
-            height: newCard.imageUrl ? "100%" : "0px",
-            padding: newCard.imageUrl ? "0 20px" : "0px",
+            width: newCard.image ? "100%" : "0px",
+            height: newCard.image ? "100%" : "0px",
+            padding: newCard.image ? "0 20px" : "0px",
             overflow: "hidden",
           }}
         >

--- a/src/components/form/card/NewCardList.module.css
+++ b/src/components/form/card/NewCardList.module.css
@@ -11,5 +11,4 @@
 .cardList {
   display: flex;
   align-items: center;
-  transition: transform 0.5s ease-in-out; /* 부드러운 전환 효과를 위해 */
 }

--- a/src/components/form/card/NewCardList.module.css
+++ b/src/components/form/card/NewCardList.module.css
@@ -11,4 +11,5 @@
 .cardList {
   display: flex;
   align-items: center;
+  transition: transform 0.3s ease-in-out; /* 부드러운 전환 효과를 위해 */
 }

--- a/src/components/form/card/NewCardList.module.css
+++ b/src/components/form/card/NewCardList.module.css
@@ -5,7 +5,7 @@
 }
 
 .cardListContainer {
-  width: 600px;
+  width: 750px;
 }
 
 .cardList {

--- a/src/components/form/card/NewCardList.tsx
+++ b/src/components/form/card/NewCardList.tsx
@@ -11,7 +11,9 @@ import {
 
 const NewCardDetails = () => {
   // cardList 관련 리덕스
-  const cardList = useSelector((state: RootState) => state.newPost.cards);
+  const cardList = useSelector(
+    (state: RootState) => state.newPost.postDetail.cards
+  );
   const dispatch = useDispatch();
   // 인덱스 & 캐러셀 설정
   const [activeIndex, setActiveIndex] = useState(0);

--- a/src/components/form/card/NewCardList.tsx
+++ b/src/components/form/card/NewCardList.tsx
@@ -8,7 +8,7 @@ import {
   addCardBack,
   addCardFront,
 } from "../../../redux/reducers/newPost/newPostReducers";
-import uuid from "react-uuid";
+import { validateCardDetails } from "utils/card/validateCardDetails";
 
 const NewCardDetails = () => {
   // cardList 관련 리덕스
@@ -21,6 +21,7 @@ const NewCardDetails = () => {
   const cardCarousel = useRef<HTMLDivElement>(null);
 
   const increaseIndex = () => {
+    if (!validateCardDetails(cardList[activeIndex])) return;
     if (activeIndex + 1 === cardList.length) {
       dispatch(addCardBack());
     }
@@ -28,8 +29,8 @@ const NewCardDetails = () => {
   };
 
   const decreaseIndex = () => {
+    if (!validateCardDetails(cardList[activeIndex])) return;
     if (activeIndex - 1 < 0) {
-      console.log("add front");
       dispatch(addCardFront());
     } else {
       setActiveIndex((prevIndex) => prevIndex - 1);
@@ -41,8 +42,8 @@ const NewCardDetails = () => {
   }
   useEffect(() => {
     if (cardList.length - 1 < activeIndex) setActiveIndex(cardList.length - 1);
-    console.log(activeIndex);
-  }, [cardList]);
+    //eslint-disable-next-line
+  }, [cardList.length]);
 
   return (
     <div className={formStyles.formWrapper}>

--- a/src/components/form/card/NewCardList.tsx
+++ b/src/components/form/card/NewCardList.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import formStyles from "./NewCardList.module.css";
 import CardPaging from "components/paging/card/CardPaging";
 import CardForm from "./CardForm";
@@ -8,6 +8,7 @@ import {
   addCardBack,
   addCardFront,
 } from "../../../redux/reducers/newPost/newPostReducers";
+import uuid from "react-uuid";
 
 const NewCardDetails = () => {
   // cardList 관련 리덕스
@@ -28,13 +29,20 @@ const NewCardDetails = () => {
 
   const decreaseIndex = () => {
     if (activeIndex - 1 < 0) {
+      console.log("add front");
       dispatch(addCardFront());
     } else {
       setActiveIndex((prevIndex) => prevIndex - 1);
     }
   };
 
-  if (!cardList) return null;
+  if (!cardList) {
+    dispatch(addCardBack());
+  }
+  useEffect(() => {
+    if (cardList.length - 1 < activeIndex) setActiveIndex(cardList.length - 1);
+    console.log(activeIndex);
+  }, [cardList]);
 
   return (
     <div className={formStyles.formWrapper}>
@@ -48,7 +56,11 @@ const NewCardDetails = () => {
         >
           {cardList.map((card, index) => {
             return (
-              <CardForm key={index} cardIndex={index} cardDetails={card} />
+              <CardForm
+                key={card.cardId}
+                cardIndex={index}
+                cardDetails={card}
+              />
             );
           })}
         </div>

--- a/src/components/form/card/NewCardList.tsx
+++ b/src/components/form/card/NewCardList.tsx
@@ -52,7 +52,7 @@ const NewCardDetails = () => {
           className={formStyles.cardList}
           ref={cardCarousel}
           style={{
-            transform: `translate3d(${activeIndex * -600}px, 0, 0)`,
+            transform: `translate3d(${activeIndex * -750}px, 0, 0)`,
           }}
         >
           {cardList.map((card, index) => {

--- a/src/components/form/post/NewPostDetails.module.css
+++ b/src/components/form/post/NewPostDetails.module.css
@@ -30,6 +30,34 @@
 .input:focus {
   border: 1px solid var(--main-theme-color);
 }
+.hashTagContainer {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  grid-gap: 4px;
+}
+
+.hashTag {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  grid-gap: 3px;
+  border-radius: 8px;
+  padding: 2px 3px;
+  width: fit-content;
+  background-color: var(--main-theme-color);
+  color: white;
+  font-size: 1.2rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.hashTag:hover {
+  transform: scale(1.05);
+  transition: 0.2s all ease-in-out;
+}
 
 @media (max-width: 768px) {
   .cardSection {

--- a/src/components/form/post/NewPostDetails.module.css
+++ b/src/components/form/post/NewPostDetails.module.css
@@ -64,3 +64,19 @@
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   }
 }
+
+.addBtn {
+  border: 1px solid var(--main-theme-color);
+  background-color: white;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: var(--main-theme-color);
+  padding: 3px 8px;
+  border-radius: 8px;
+  transition: all 0.1s ease-in-out;
+}
+
+.addBtn:hover {
+  background-color: var(--main-theme-color);
+  color: white;
+}

--- a/src/components/form/post/NewPostDetails.tsx
+++ b/src/components/form/post/NewPostDetails.tsx
@@ -11,10 +11,14 @@ import {
 import { IoCloseSharp } from "react-icons/io5";
 
 function NewPostDetails() {
-  const cardList = useSelector((state: RootState) => state.newPost.cards);
+  const cardList = useSelector(
+    (state: RootState) => state.newPost.postDetail.cards
+  );
   // post redux dispatch
   const dispatch = useDispatch();
-  const hashTags = useSelector((state: RootState) => state.newPost.hashtags);
+  const hashTags = useSelector(
+    (state: RootState) => state.newPost.postDetail.hashtags
+  );
 
   const [newHashTag, setNewHashTag] = useState<string>("");
   const handleAddHashTag = (event: React.FormEvent<HTMLFormElement>) => {

--- a/src/components/form/post/NewPostDetails.tsx
+++ b/src/components/form/post/NewPostDetails.tsx
@@ -4,8 +4,11 @@ import { RootState } from "redux/store/store";
 
 import formStyles from "./NewPostDetails.module.css";
 import { useState } from "react";
-import { addHashTags } from "../../../redux/reducers/newPost/newPostReducers";
-import { Cancel } from "@mui/icons-material";
+import {
+  addHashTags,
+  removeHashTags,
+} from "../../../redux/reducers/newPost/newPostReducers";
+import { IoCloseSharp } from "react-icons/io5";
 
 function NewPostDetails() {
   const cardList = useSelector((state: RootState) => state.newPost.cards);
@@ -17,6 +20,9 @@ function NewPostDetails() {
   const handleAddHashTag = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     dispatch(addHashTags(newHashTag));
+  };
+  const handleRemoveHashTag = (tag: string) => {
+    dispatch(removeHashTags(tag));
   };
   return (
     <div className={formStyles.postDetailWrapper}>
@@ -37,14 +43,20 @@ function NewPostDetails() {
             />
             <button type="submit">추가</button>
           </form>
-          {hashTags.map((tags, index) => {
-            return (
-              <span key={index}>
-                {`# ${tags}`}
-                <Cancel />
-              </span>
-            );
-          })}
+          <section className={formStyles.hashTagContainer}>
+            {hashTags.map((tag, index) => {
+              return (
+                <div key={index} className={formStyles.hashTag}>
+                  <span>{`#${tag}`}</span>
+                  <IoCloseSharp
+                    className={formStyles.deleteHashTag}
+                    size={"14px"}
+                    onClick={() => handleRemoveHashTag(tag)}
+                  />
+                </div>
+              );
+            })}
+          </section>
         </div>
       </div>
     </div>

--- a/src/components/form/post/NewPostDetails.tsx
+++ b/src/components/form/post/NewPostDetails.tsx
@@ -7,20 +7,24 @@ import { useState } from "react";
 import {
   addHashTags,
   removeHashTags,
+  setTitle,
 } from "../../../redux/reducers/newPost/newPostReducers";
 import { IoCloseSharp } from "react-icons/io5";
 
 function NewPostDetails() {
-  const cardList = useSelector(
-    (state: RootState) => state.newPost.postDetail.cards
-  );
   // post redux dispatch
   const dispatch = useDispatch();
   const hashTags = useSelector(
     (state: RootState) => state.newPost.postDetail.hashtags
   );
-
+  const cardList = useSelector(
+    (state: RootState) => state.newPost.postDetail.cards
+  );
   const [newHashTag, setNewHashTag] = useState<string>("");
+
+  const handleTitle = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setTitle(event.target.value));
+  };
   const handleAddHashTag = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     dispatch(addHashTags(newHashTag));
@@ -35,8 +39,9 @@ function NewPostDetails() {
         <input
           id="title"
           className={`${formStyles.input} ${formStyles.inputTitle}`}
+          onChange={handleTitle}
           placeholder="타이틀을 입력하세요..."
-        ></input>
+        />
         <div>
           <form onSubmit={handleAddHashTag}>
             <input

--- a/src/components/form/post/NewPostDetails.tsx
+++ b/src/components/form/post/NewPostDetails.tsx
@@ -50,7 +50,9 @@ function NewPostDetails() {
               onChange={(e) => setNewHashTag(e.target.value)}
               className={`${formStyles.input} ${formStyles.inputHashTag}`}
             />
-            <button type="submit">추가</button>
+            <button className={formStyles.addBtn} type="submit">
+              추가
+            </button>
           </form>
           <section className={formStyles.hashTagContainer}>
             {hashTags.map((tag, index) => {

--- a/src/components/form/post/NewPostTheme.tsx
+++ b/src/components/form/post/NewPostTheme.tsx
@@ -11,10 +11,10 @@ import {
 
 function NewPostTheme() {
   const selectedConcept = useSelector(
-    (state: RootState) => state.newPost.concept
+    (state: RootState) => state.newPost.postDetail.concept
   );
   const selectedRegion = useSelector(
-    (state: RootState) => state.newPost.region
+    (state: RootState) => state.newPost.postDetail.region
   );
   const dispatch = useDispatch();
 

--- a/src/components/form/post/NewPostTheme.tsx
+++ b/src/components/form/post/NewPostTheme.tsx
@@ -33,7 +33,7 @@ function NewPostTheme() {
         {Object.entries(conceptOptionType).map(([key, value]) => (
           <button
             className={
-              selectedConcept === value
+              selectedConcept === key
                 ? formStyles.selectedOptionBtn
                 : formStyles.optionBtn
             }
@@ -49,7 +49,7 @@ function NewPostTheme() {
         {Object.entries(regionOptionType).map(([key, value]) => (
           <button
             className={
-              selectedRegion === value
+              selectedRegion === key
                 ? formStyles.selectedOptionBtn
                 : formStyles.optionBtn
             }

--- a/src/components/grid/cardListGrid/CardGrid.module.css
+++ b/src/components/grid/cardListGrid/CardGrid.module.css
@@ -1,0 +1,38 @@
+/* CardForm.module.css */
+.section {
+  width: 400px;
+  height: 280px;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.card {
+  position: relative;
+  width: 100%;
+}
+
+.img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.deleteBtn {
+  top: 0;
+  right: 0;
+  position: absolute;
+  font-size: 24px;
+  color: tomato;
+  border: none;
+  cursor: pointer;
+}
+
+.deleteBtn:hover {
+  transform: scale(1.2);
+  transition: transform 0.2s ease-in-out;
+}

--- a/src/components/grid/cardListGrid/CardGrid.module.css
+++ b/src/components/grid/cardListGrid/CardGrid.module.css
@@ -4,7 +4,7 @@
   height: 280px;
   overflow-y: auto;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(100px, 2fr));
   gap: 10px;
   margin-bottom: 20px;
 }
@@ -12,9 +12,11 @@
 .card {
   position: relative;
   width: 100%;
+  height: 100%;
 }
 
 .img {
+  position: relative;
   width: 100%;
   height: auto;
   aspect-ratio: 1 / 1;
@@ -23,20 +25,12 @@
 }
 
 .index {
-  opacity: 0;
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 2;
   font-size: 1.4rem;
   font-weight: bold;
+  color: white;
 }
 
 .deleteBtn {
-  opacity: 0;
-  top: 0;
-  right: 0;
-  position: absolute;
   font-size: 24px;
   color: tomato;
   border: none;
@@ -44,11 +38,30 @@
   transition: all 0.2s ease-in-out;
 }
 
-.card:hover .index,
-.card:hover .deleteBtn {
-  opacity: 1;
-}
-
 .deleteBtn:hover {
   transform: scale(1.2);
+}
+
+.imgContainer {
+  position: relative;
+  width: 100%;
+}
+
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2); /* 오버레이의 배경 색상과 투명도 */
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
+  opacity: 0; /* 기본적으로 오버레이 숨김 */
+  transition: opacity 0.2s ease-in-out; /* 부드러운 효과 */
+}
+
+.imgContainer:hover .overlay {
+  opacity: 1; /* 이미지 위에 마우스를 올리면 오버레이 표시 */
 }

--- a/src/components/grid/cardListGrid/CardGrid.module.css
+++ b/src/components/grid/cardListGrid/CardGrid.module.css
@@ -22,7 +22,18 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
+.index {
+  opacity: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  font-size: 1.4rem;
+  font-weight: bold;
+}
+
 .deleteBtn {
+  opacity: 0;
   top: 0;
   right: 0;
   position: absolute;
@@ -30,9 +41,14 @@
   color: tomato;
   border: none;
   cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+.card:hover .index,
+.card:hover .deleteBtn {
+  opacity: 1;
 }
 
 .deleteBtn:hover {
   transform: scale(1.2);
-  transition: transform 0.2s ease-in-out;
 }

--- a/src/components/grid/cardListGrid/CardGrid.module.css
+++ b/src/components/grid/cardListGrid/CardGrid.module.css
@@ -16,6 +16,7 @@
 }
 
 .img {
+  box-sizing: border-box;
   position: relative;
   width: 100%;
   height: auto;
@@ -64,4 +65,9 @@
 
 .imgContainer:hover .overlay {
   opacity: 1; /* 이미지 위에 마우스를 올리면 오버레이 표시 */
+}
+
+.selected {
+  border: 3px solid rgba(20, 196, 163, 0.7); /* 테두리 */
+  filter: brightness(120%); /* 밝기 조절 */
 }

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -30,7 +30,7 @@ const CardGrid = ({ cards }: CardProps) => {
           key={index}
           id={`card-${index}`}
           style={imgStyle}
-          src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.imageUrl}`}
+          src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
           alt={`Card ${index}`}
         />
       ))}

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -1,5 +1,7 @@
 // CardGrid.tsx
 import INewCard from "interface/card/INewCard";
+import gridStyles from "./CardGrid.module.css";
+import { IoMdCloseCircle } from "react-icons/io";
 import React from "react";
 
 interface CardProps {
@@ -7,32 +9,18 @@ interface CardProps {
 }
 
 const CardGrid = ({ cards }: CardProps) => {
-  const sectionStyle = {
-    width: "400px",
-    display: "grid",
-    gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))",
-    gap: "10px",
-    marginBottom: "20px",
-  };
-
-  const imgStyle = {
-    width: "100%",
-    height: "auto",
-    aspectRatio: "1 / 1",
-    borderRadius: "8px",
-    boxShadow: "0 2px 5px rgba(0,0,0,0.2)",
-  };
-
   return (
-    <section style={sectionStyle}>
+    <section className={gridStyles.section}>
       {cards.map((card, index) => (
-        <img
-          key={index}
-          id={`card-${index}`}
-          style={imgStyle}
-          src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
-          alt={`Card ${index}`}
-        />
+        <div key={index} className={gridStyles.card}>
+          <IoMdCloseCircle className={gridStyles.deleteBtn} size={"20px"} />
+          <img
+            id={`card-${index}`}
+            className={gridStyles.img}
+            src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
+            alt={`Card ${index}`}
+          />
+        </div>
       ))}
     </section>
   );

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -18,18 +18,22 @@ const CardGrid = ({ cards }: CardProps) => {
     <section className={gridStyles.section}>
       {cards.map((card, index) => (
         <div key={index} className={gridStyles.card}>
-          <span className={gridStyles.index}>{index + 1}</span>
-          <IoMdCloseCircle
-            className={gridStyles.deleteBtn}
-            size={"20px"}
-            onClick={() => handleRemoveCard(index)}
-          />
-          <img
-            id={`card-${index}`}
-            className={gridStyles.img}
-            src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
-            alt={`Card ${index}`}
-          />
+          <div className={gridStyles.imgContainer}>
+            <img
+              id={`card-${index}`}
+              className={gridStyles.img}
+              src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
+              alt={`Card ${index}`}
+            />
+            <div className={gridStyles.overlay}>
+              <span className={gridStyles.index}>{index + 1}</span>
+              <IoMdCloseCircle
+                className={gridStyles.deleteBtn}
+                size={"20px"}
+                onClick={() => handleRemoveCard(index)}
+              />
+            </div>
+          </div>
         </div>
       ))}
     </section>

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -3,29 +3,47 @@ import INewCard from "interface/card/INewCard";
 import gridStyles from "./CardGrid.module.css";
 import { IoMdCloseCircle } from "react-icons/io";
 import React from "react";
-import { useDispatch } from "react-redux";
-import { removeCardByIndex } from "../../../redux/reducers/newPost/newPostReducers";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  removeCardByIndex,
+  setThumbnail,
+} from "../../../redux/reducers/newPost/newPostReducers";
+import { RootState } from "redux/store/store";
 interface CardProps {
   cards: INewCard[];
 }
 
 const CardGrid = ({ cards }: CardProps) => {
+  const selectedThumbnailIndex = useSelector(
+    (state: RootState) => state.newPost.postDetail.thumbnailIndex
+  );
   const dispatch = useDispatch();
   const handleRemoveCard = (index: number) => {
     dispatch(removeCardByIndex(index));
+  };
+  const handleSelectThumbnail = (index: number) => {
+    console.log("dkfjl;s");
+    dispatch(setThumbnail(index));
   };
   return (
     <section className={gridStyles.section}>
       {cards.map((card, index) => (
         <div key={index} className={gridStyles.card}>
-          <div className={gridStyles.imgContainer}>
+          <div key={index} className={gridStyles.card}>
             <img
               id={`card-${index}`}
-              className={gridStyles.img}
+              className={`${gridStyles.img} ${
+                selectedThumbnailIndex === index ? gridStyles.selected : ""
+              }`}
               src={`${process.env.REACT_APP_BUCKET_BASEURL}/${card.image}`}
               alt={`Card ${index}`}
             />
-            <div className={gridStyles.overlay}>
+            <div
+              onClick={() => handleSelectThumbnail(index)}
+              className={`${gridStyles.overlay} ${
+                selectedThumbnailIndex === index ? gridStyles.selected : ""
+              }`}
+            >
               <span className={gridStyles.index}>{index + 1}</span>
               <IoMdCloseCircle
                 className={gridStyles.deleteBtn}

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -18,6 +18,7 @@ const CardGrid = ({ cards }: CardProps) => {
   const imgStyle = {
     width: "100%",
     height: "auto",
+    aspectRatio: "1 / 1",
     borderRadius: "8px",
     boxShadow: "0 2px 5px rgba(0,0,0,0.2)",
   };

--- a/src/components/grid/cardListGrid/CardGrid.tsx
+++ b/src/components/grid/cardListGrid/CardGrid.tsx
@@ -3,17 +3,27 @@ import INewCard from "interface/card/INewCard";
 import gridStyles from "./CardGrid.module.css";
 import { IoMdCloseCircle } from "react-icons/io";
 import React from "react";
-
+import { useDispatch } from "react-redux";
+import { removeCardByIndex } from "../../../redux/reducers/newPost/newPostReducers";
 interface CardProps {
   cards: INewCard[];
 }
 
 const CardGrid = ({ cards }: CardProps) => {
+  const dispatch = useDispatch();
+  const handleRemoveCard = (index: number) => {
+    dispatch(removeCardByIndex(index));
+  };
   return (
     <section className={gridStyles.section}>
       {cards.map((card, index) => (
         <div key={index} className={gridStyles.card}>
-          <IoMdCloseCircle className={gridStyles.deleteBtn} size={"20px"} />
+          <span className={gridStyles.index}>{index + 1}</span>
+          <IoMdCloseCircle
+            className={gridStyles.deleteBtn}
+            size={"20px"}
+            onClick={() => handleRemoveCard(index)}
+          />
           <img
             id={`card-${index}`}
             className={gridStyles.img}

--- a/src/components/modal/newPost/NewPostModal.module.css
+++ b/src/components/modal/newPost/NewPostModal.module.css
@@ -29,7 +29,7 @@
   background-color: white;
   border-radius: 8px;
   overflow: auto;
-  transition: all 2s ease;
+  transition: all 0.2s ease;
   border: 1px solid #ccc;
 }
 

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -13,11 +13,13 @@ import INewPost from "interface/post/INewPost";
 import { toast } from "react-toastify";
 import {
   filterCardNoneImage,
+  resetPostDetails,
   setPostId,
   setRoutePoint,
 } from "../../../redux/reducers/newPost/newPostReducers";
 import { QontoConnector, QontoStepIcon } from "./QontoStepStyle";
 import postNewPost from "api/post/postNewPost";
+import { validateCardList } from "utils/card/validateCardDetails";
 
 interface FormComponentsType {
   name: string;
@@ -31,7 +33,7 @@ const formComponents: FormComponentsType[] = [
 ];
 
 function NewPostModal() {
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
   const [postFormIndex, setPostFormIndex] = useState<number>(0);
   const postDetails: INewPost = useSelector(
     (state: RootState) => state.newPost.postDetail
@@ -75,10 +77,11 @@ function NewPostModal() {
           toast.error("theme 와 region은 필수 항목입니다.");
         }
       } else if (postFormIndex === 1) {
-        console.log(postDetails.cards);
         if (postDetails.cards) {
           dispatch(filterCardNoneImage());
-          setPostFormIndex((prev) => prev + 1);
+          if (validateCardList(postDetails.cards)) {
+            setPostFormIndex((prev) => prev + 1);
+          }
         } else {
           toast.error("최소 하나의 카드를 입력해주세요");
         }
@@ -99,7 +102,11 @@ function NewPostModal() {
   };
 
   const uploadPost = async () => {
-    await postNewPost(postDetails);
+    const result = await postNewPost(postDetails);
+    if (result) {
+      dispatch(resetPostDetails());
+      closeModal(ModalOption.POST);
+    }
   };
 
   return (

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -97,8 +97,12 @@ function NewPostModal() {
   };
 
   const handleUploadPost = () => {
-    dispatch(setRoutePoint());
-    uploadPost();
+    if (postDetails.title) {
+      dispatch(setRoutePoint());
+      uploadPost();
+    } else {
+      toast.error("제목은 필수항목입니다.");
+    }
   };
 
   const uploadPost = async () => {

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -11,7 +11,10 @@ import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "redux/store/store";
 import INewPost from "interface/post/INewPost";
 import { toast } from "react-toastify";
-import { setPostId } from "../../../redux/reducers/newPost/newPostReducers";
+import {
+  filterCardNoneImage,
+  setPostId,
+} from "../../../redux/reducers/newPost/newPostReducers";
 import { QontoConnector, QontoStepIcon } from "./QontoStepStyle";
 
 interface FormComponentsType {
@@ -72,6 +75,7 @@ function NewPostModal() {
       } else if (postFormIndex === 1) {
         console.log(postDetails.cards);
         if (postDetails.cards) {
+          dispatch(filterCardNoneImage());
           setPostFormIndex((prev) => prev + 1);
         } else {
           toast.error("최소 하나의 카드를 입력해주세요");

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -14,8 +14,10 @@ import { toast } from "react-toastify";
 import {
   filterCardNoneImage,
   setPostId,
+  setRoutePoint,
 } from "../../../redux/reducers/newPost/newPostReducers";
 import { QontoConnector, QontoStepIcon } from "./QontoStepStyle";
+import postNewPost from "api/post/postNewPost";
 
 interface FormComponentsType {
   name: string;
@@ -91,7 +93,14 @@ function NewPostModal() {
     }
   };
 
-  const handleUploadPost = () => {};
+  const handleUploadPost = () => {
+    dispatch(setRoutePoint());
+    uploadPost();
+  };
+
+  const uploadPost = async () => {
+    await postNewPost(postDetails);
+  };
 
   return (
     <div className={modalStyles.modalBackdrop} onClick={handleBackdropClick}>

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -12,6 +12,7 @@ import { RootState } from "redux/store/store";
 import INewPost from "interface/post/INewPost";
 import { toast } from "react-toastify";
 import { setPostId } from "../../../redux/reducers/newPost/newPostReducers";
+import { QontoConnector, QontoStepIcon } from "./QontoStepStyle";
 
 interface FormComponentsType {
   name: string;
@@ -32,21 +33,6 @@ function NewPostModal() {
   );
   const modalRef = useRef<HTMLDivElement>(null); // 모달 DOM에 접근하기 위한 ref
   const dispatch = useDispatch();
-
-  // useEffect(() => {
-  //   const modal = modalRef.current;
-  //   console.log(postFormIndex);
-  //   if (modal) {
-  //     // 모달의 최대 크기를 현재 컨텐츠 크기에 기반하여 설정
-  //     const contentWidth = modal.offsetWidth; // 첫 번째 자식 요소의 너비
-  //     const contentHeight = modal.offsetHeight; // 첫 번째 자식 요소의 높이
-  //     console.log(contentHeight);
-  //     console.log(contentWidth);
-  //     modalContent의 스타일을 업데이트하여 transition 효과 적용
-  //     modal.style.width = `${contentWidth}px`;
-  //     modal.style.height = `${contentHeight}px`;
-  //   }
-  // }, [postFormIndex]);
 
   // Esc 눌렀을때 모달 탈출n
   const handleKeyUp = (event: KeyboardEvent) => {
@@ -124,10 +110,24 @@ function NewPostModal() {
               <ActionBtn name="업로드" handleClick={handleUploadPost} />
             )}
           </div>
-          <Stepper alternativeLabel activeStep={postFormIndex}>
+          <Stepper
+            alternativeLabel
+            activeStep={postFormIndex}
+            connector={<QontoConnector />}
+          >
             {formComponents.map((Component, index) => (
               <Step key={index}>
-                <StepLabel>{Component.name}</StepLabel>
+                <StepLabel
+                  StepIconComponent={QontoStepIcon}
+                  sx={{
+                    ".MuiStepLabel-label": {
+                      fontWeight: "500",
+                      fontSize: "1.4rem",
+                    },
+                  }}
+                >
+                  {Component.name}
+                </StepLabel>
               </Step>
             ))}
           </Stepper>

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -32,7 +32,7 @@ function NewPostModal() {
   const { openModal } = useModal();
   const [postFormIndex, setPostFormIndex] = useState<number>(0);
   const postDetails: INewPost = useSelector(
-    (state: RootState) => state.newPost
+    (state: RootState) => state.newPost.postDetail
   );
   const modalRef = useRef<HTMLDivElement>(null); // 모달 DOM에 접근하기 위한 ref
   const dispatch = useDispatch();

--- a/src/components/modal/newPost/NewPostModal.tsx
+++ b/src/components/modal/newPost/NewPostModal.tsx
@@ -96,16 +96,16 @@ function NewPostModal() {
     }
   };
 
-  const handleUploadPost = () => {
+  const handleUploadButtonClick = () => {
     if (postDetails.title) {
       dispatch(setRoutePoint());
-      uploadPost();
+      submitPostToServer();
     } else {
       toast.error("제목은 필수항목입니다.");
     }
   };
 
-  const uploadPost = async () => {
+  const submitPostToServer = async () => {
     const result = await postNewPost(postDetails);
     if (result) {
       dispatch(resetPostDetails());
@@ -131,7 +131,7 @@ function NewPostModal() {
             {postFormIndex < formComponents.length - 1 ? (
               <ActionBtn name="다음" handleClick={increaseFormIndex} />
             ) : (
-              <ActionBtn name="업로드" handleClick={handleUploadPost} />
+              <ActionBtn name="업로드" handleClick={handleUploadButtonClick} />
             )}
           </div>
           <Stepper

--- a/src/components/modal/newPost/QontoStepStyle.tsx
+++ b/src/components/modal/newPost/QontoStepStyle.tsx
@@ -1,0 +1,68 @@
+import { styled } from "@mui/material/styles";
+import { Check } from "@mui/icons-material";
+import {
+  StepConnector,
+  stepConnectorClasses,
+  StepIconProps,
+} from "@mui/material";
+
+export const QontoConnector = styled(StepConnector)(({ theme }) => ({
+  [`&.${stepConnectorClasses.alternativeLabel}`]: {
+    top: 10,
+    left: "calc(-50% + 16px)",
+    right: "calc(50% + 16px)",
+  },
+  [`&.${stepConnectorClasses.active}`]: {
+    [`& .${stepConnectorClasses.line}`]: {
+      borderColor: "#13c4a3",
+    },
+  },
+  [`&.${stepConnectorClasses.completed}`]: {
+    [`& .${stepConnectorClasses.line}`]: {
+      borderColor: "#13c4a3",
+    },
+  },
+  [`& .${stepConnectorClasses.line}`]: {
+    borderColor:
+      theme.palette.mode === "dark" ? theme.palette.grey[800] : "#eaeaf0",
+    borderTopWidth: 3,
+    borderRadius: 1,
+  },
+}));
+
+const QontoStepIconRoot = styled("div")<{ ownerState: { active?: boolean } }>(
+  ({ theme, ownerState }) => ({
+    color: theme.palette.mode === "dark" ? theme.palette.grey[700] : "#eaeaf0",
+    display: "flex",
+    height: 22,
+    alignItems: "center",
+    ...(ownerState.active && {
+      color: "#13c4a3",
+    }),
+    "& .QontoStepIcon-completedIcon": {
+      color: "#13c4a3",
+      zIndex: 1,
+      fontSize: 18,
+    },
+    "& .QontoStepIcon-circle": {
+      width: 8,
+      height: 8,
+      borderRadius: "50%",
+      backgroundColor: "currentColor",
+    },
+  })
+);
+
+export function QontoStepIcon(props: StepIconProps) {
+  const { active, completed, className } = props;
+
+  return (
+    <QontoStepIconRoot ownerState={{ active }} className={className}>
+      {completed ? (
+        <Check className="QontoStepIcon-completedIcon" />
+      ) : (
+        <div className="QontoStepIcon-circle" />
+      )}
+    </QontoStepIconRoot>
+  );
+}

--- a/src/components/modal/warn/WarningModal.tsx
+++ b/src/components/modal/warn/WarningModal.tsx
@@ -10,7 +10,9 @@ import { RootState } from "redux/store/store";
 const WarningModal = () => {
   const { closeModal } = useModal();
   const { deleteImage } = useBucket();
-  const cardList = useSelector((state: RootState) => state.newPost.cards);
+  const cardList = useSelector(
+    (state: RootState) => state.newPost.postDetail.cards
+  );
   const dispatch = useDispatch();
 
   // "나가기" 버튼 클릭 시 실행될 함수

--- a/src/components/modal/warn/WarningModal.tsx
+++ b/src/components/modal/warn/WarningModal.tsx
@@ -19,8 +19,8 @@ const WarningModal = () => {
   const handleExit = () => {
     dispatch(resetPostDetails()); // 포스트 상세 정보를 리셋
     cardList.forEach((card) => {
-      if (card.imageUrl) {
-        deleteImage(card.imageUrl);
+      if (card.image) {
+        deleteImage(card.image);
       }
     });
     closeModal(ModalOption.WARNING);

--- a/src/enum/post/conceptOptionType.ts
+++ b/src/enum/post/conceptOptionType.ts
@@ -1,15 +1,15 @@
 enum conceptOptionType {
   FOOD = "음식",
-  CAFE = "카페",
   NATURE = "자연",
   CITY = "도시관광",
   PHOTO = "사진&명소",
   HOT = "인기게시글",
   WALK = "도보여행",
   CAR = "자동차",
-  BUS = "버스",
   TRAIN = "기차여행",
-  AIRPLANE = "비행기여행",
+  // CAFE = "카페",
+  // BUS = "버스",
+  // AIRPLANE = "비행기여행",
 }
 
 export default conceptOptionType;

--- a/src/hooks/map/useKakaoMap.ts
+++ b/src/hooks/map/useKakaoMap.ts
@@ -55,7 +55,6 @@ const useKakaoMap = ({ latitude, longitude, level }: KakaoMapProps) => {
     if (!mapRef.current) return;
     const places = new kakao.maps.services.Places();
     places.setMap(mapRef);
-    console.log(places.set);
     places.keywordSearch(keyword, searchResult);
   };
 

--- a/src/hooks/modal/newFile/useSingleCard.ts
+++ b/src/hooks/modal/newFile/useSingleCard.ts
@@ -5,14 +5,14 @@ export const useSingleCard = (initialCard: INewCard) => {
   const [newCard, setNewCard] = useState<INewCard>(initialCard);
 
   const handleImageChange = (imageUrl: string) => {
-    setNewCard({ ...newCard, imageUrl: imageUrl });
+    setNewCard({ ...newCard, image: imageUrl });
   };
 
   const handlePlaceChange = (place: any) => {
     if (!place) return;
     setNewCard({
       ...newCard,
-      location: place.addressName,
+      location: place.address_name,
       latitude: place.x,
       longitude: place.y,
     });

--- a/src/hooks/modal/newFile/useSingleCard.ts
+++ b/src/hooks/modal/newFile/useSingleCard.ts
@@ -8,6 +8,10 @@ export const useSingleCard = (initialCard: INewCard) => {
     setNewCard({ ...newCard, image: imageUrl });
   };
 
+  const handleImageRemove = () => {
+    setNewCard({ ...newCard, image: undefined });
+  };
+
   const handlePlaceChange = (place: any) => {
     if (!place) return;
     setNewCard({
@@ -29,5 +33,6 @@ export const useSingleCard = (initialCard: INewCard) => {
     handleImageChange,
     handleContentsChange,
     handlePlaceChange,
+    handleImageRemove,
   };
 };

--- a/src/interface/card/INewCard.ts
+++ b/src/interface/card/INewCard.ts
@@ -1,4 +1,5 @@
 interface INewCard {
+  cardId: string;
   cardIndex: number | null;
   location: string | null;
   latitude: number | null;

--- a/src/interface/card/INewCard.ts
+++ b/src/interface/card/INewCard.ts
@@ -1,4 +1,5 @@
 interface INewCard {
+  cardIndex: number | null;
   location: string | null;
   latitude: string | null;
   longitude: string | null;

--- a/src/interface/card/INewCard.ts
+++ b/src/interface/card/INewCard.ts
@@ -1,9 +1,9 @@
 interface INewCard {
   cardIndex: number | null;
   location: string | null;
-  latitude: string | null;
-  longitude: string | null;
-  imageUrl: string | undefined;
+  latitude: number | null;
+  longitude: number | null;
+  image: string | undefined;
   content: string | null;
 }
 

--- a/src/interface/post/INewPost.ts
+++ b/src/interface/post/INewPost.ts
@@ -6,8 +6,8 @@ interface INewPost {
   title: string | null;
   routePoint: string | null;
   thumbnailIndex: number | null;
-  concept: conceptOptionType | null;
-  region: regionOptionType | null;
+  concept: string | null;
+  region: string | null;
   cards: INewCard[];
   hashtags: string[];
 }

--- a/src/interface/post/INewPost.ts
+++ b/src/interface/post/INewPost.ts
@@ -3,7 +3,6 @@ import regionOptionType from "../../enum/post/regionOptionType";
 import INewCard from "../card/INewCard";
 
 interface INewPost {
-  postId: string | null;
   title: string | null;
   routePoint: string | null;
   thumbnailIndex: number | null;

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -62,6 +62,9 @@ const newPost = createSlice({
       const regionKey = getEnumKeyByEnumValue(regionOptionType, action.payload);
       state.postDetail.region = regionKey;
     },
+    setThumbnail: (state, action: PayloadAction<number>) => {
+      state.postDetail.thumbnailIndex = action.payload;
+    },
     setRoutePoint: (state) => {
       const routePointDate = state.postDetail.cards
         .filter((card) => card.latitude && card.longitude)
@@ -118,6 +121,7 @@ export const {
   setPostId,
   setTitle,
   setConcept,
+  setThumbnail,
   setRegion,
   setRoutePoint,
   updateCardAtIndex,

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -6,6 +6,7 @@ import INewCard from "interface/card/INewCard";
 import uuid from "react-uuid";
 
 const initCard: INewCard = {
+  cardIndex: null,
   location: null,
   latitude: null,
   longitude: null,
@@ -13,15 +14,22 @@ const initCard: INewCard = {
   content: null,
 };
 
-const initialState: INewPost = {
+interface PostDetailType {
+  postId: string | null;
+  postDetail: INewPost;
+}
+
+const initialState: PostDetailType = {
   postId: null,
-  title: null,
-  routePoint: null,
-  thumbnailIndex: null,
-  concept: null,
-  region: null,
-  cards: [initCard],
-  hashtags: [],
+  postDetail: {
+    title: null,
+    routePoint: null,
+    thumbnailIndex: null,
+    concept: null,
+    region: null,
+    cards: [initCard],
+    hashtags: [],
+  },
 };
 
 const newPost = createSlice({
@@ -33,34 +41,39 @@ const newPost = createSlice({
       console.log(state.postId);
     },
     setConcept: (state, action: PayloadAction<conceptOptionType>) => {
-      state.concept = action.payload;
+      state.postDetail.concept = action.payload;
     },
     setRegion: (state, action: PayloadAction<regionOptionType>) => {
-      state.region = action.payload;
+      state.postDetail.region = action.payload;
     },
     updateCardAtIndex: (
       state,
       action: PayloadAction<{ index: number; newCard: INewCard }>
     ) => {
       const { index, newCard } = action.payload;
-      if (index >= 0 && index < state.cards.length) {
-        state.cards[index] = { ...state.cards[index], ...newCard };
+      if (index >= 0 && index < state.postDetail.cards.length) {
+        state.postDetail.cards[index] = {
+          ...state.postDetail.cards[index],
+          ...newCard,
+        };
       }
     },
     filterCardNoneImage: (state) => {
-      state.cards = state.cards.filter((card) => card.imageUrl);
+      state.postDetail.cards = state.postDetail.cards.filter(
+        (card) => card.imageUrl
+      );
     },
     addCardFront: (state) => {
-      state.cards.unshift({ ...initCard });
+      state.postDetail.cards.unshift({ ...initCard });
     },
     addCardBack: (state) => {
-      state.cards.push({ ...initCard });
+      state.postDetail.cards.push({ ...initCard });
     },
     addHashTags: (state, action: PayloadAction<string>) => {
-      state.hashtags.push(action.payload);
+      state.postDetail.hashtags.push(action.payload);
     },
     removeHashTags: (state, action: PayloadAction<string>) => {
-      state.hashtags = state.hashtags.filter(
+      state.postDetail.hashtags = state.postDetail.hashtags.filter(
         (hashTag) => hashTag !== action.payload
       );
     },

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -10,7 +10,7 @@ const initCard: INewCard = {
   location: null,
   latitude: null,
   longitude: null,
-  imageUrl: undefined,
+  image: undefined,
   content: null,
 };
 
@@ -32,6 +32,14 @@ const initialState: PostDetailType = {
   },
 };
 
+function getEnumKeyByEnumValue<T extends { [index: string]: string }>(
+  myEnum: T,
+  enumValue: string
+): string | null {
+  let keys = Object.keys(myEnum).filter((x) => myEnum[x] === enumValue);
+  return keys.length > 0 ? keys[0] : null;
+}
+
 const newPost = createSlice({
   name: "newPost",
   initialState,
@@ -40,11 +48,28 @@ const newPost = createSlice({
       state.postId = uuid();
       console.log(state.postId);
     },
+    setTitle: (state, action: PayloadAction<string>) => {
+      state.postDetail.title = action.payload;
+    },
     setConcept: (state, action: PayloadAction<conceptOptionType>) => {
-      state.postDetail.concept = action.payload;
+      const conceptKey = getEnumKeyByEnumValue(
+        conceptOptionType,
+        action.payload
+      );
+      state.postDetail.concept = conceptKey;
     },
     setRegion: (state, action: PayloadAction<regionOptionType>) => {
-      state.postDetail.region = action.payload;
+      const regionKey = getEnumKeyByEnumValue(regionOptionType, action.payload);
+      state.postDetail.region = regionKey;
+    },
+    setRoutePoint: (state) => {
+      const routePointDate = state.postDetail.cards
+        .filter((card) => card.latitude && card.longitude)
+        .map((card) => ({
+          latitude: card.latitude,
+          longitude: card.longitude,
+        }));
+      state.postDetail.routePoint = JSON.stringify(routePointDate);
     },
     updateCardAtIndex: (
       state,
@@ -60,7 +85,7 @@ const newPost = createSlice({
     },
     filterCardNoneImage: (state) => {
       state.postDetail.cards = state.postDetail.cards.filter(
-        (card) => card.imageUrl
+        (card) => card.image
       );
     },
     addCardFront: (state) => {
@@ -86,8 +111,10 @@ const newPost = createSlice({
 // 액션 생성자와 리듀서 내보내기
 export const {
   setPostId,
+  setTitle,
   setConcept,
   setRegion,
+  setRoutePoint,
   updateCardAtIndex,
   filterCardNoneImage,
   addCardFront,

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -60,7 +60,9 @@ const newPost = createSlice({
       state.hashtags.push(action.payload);
     },
     removeHashTags: (state, action: PayloadAction<string>) => {
-      state.hashtags.filter((hashTag) => hashTag !== action.payload);
+      state.hashtags = state.hashtags.filter(
+        (hashTag) => hashTag !== action.payload
+      );
     },
     resetPostDetails: (state) => {
       return initialState;

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -47,6 +47,9 @@ const newPost = createSlice({
         state.cards[index] = { ...state.cards[index], ...newCard };
       }
     },
+    filterCardNoneImage: (state) => {
+      state.cards = state.cards.filter((card) => card.imageUrl);
+    },
     addCardFront: (state) => {
       state.cards.unshift({ ...initCard });
     },
@@ -71,6 +74,7 @@ export const {
   setConcept,
   setRegion,
   updateCardAtIndex,
+  filterCardNoneImage,
   addCardFront,
   addCardBack,
   addHashTags,

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -47,7 +47,6 @@ const newPost = createSlice({
   reducers: {
     setPostId: (state) => {
       state.postId = uuid();
-      console.log(state.postId);
     },
     setTitle: (state, action: PayloadAction<string>) => {
       state.postDetail.title = action.payload;

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -88,6 +88,11 @@ const newPost = createSlice({
         (card) => card.image
       );
     },
+    removeCardByIndex: (state, action: PayloadAction<number>) => {
+      state.postDetail.cards = state.postDetail.cards.filter(
+        (card, index) => index !== action.payload
+      );
+    },
     addCardFront: (state) => {
       state.postDetail.cards.unshift({ ...initCard });
     },
@@ -117,6 +122,7 @@ export const {
   setRoutePoint,
   updateCardAtIndex,
   filterCardNoneImage,
+  removeCardByIndex,
   addCardFront,
   addCardBack,
   addHashTags,

--- a/src/redux/reducers/newPost/newPostReducers.ts
+++ b/src/redux/reducers/newPost/newPostReducers.ts
@@ -6,6 +6,7 @@ import INewCard from "interface/card/INewCard";
 import uuid from "react-uuid";
 
 const initCard: INewCard = {
+  cardId: "",
   cardIndex: null,
   location: null,
   latitude: null,
@@ -94,10 +95,10 @@ const newPost = createSlice({
       );
     },
     addCardFront: (state) => {
-      state.postDetail.cards.unshift({ ...initCard });
+      state.postDetail.cards.unshift({ ...initCard, cardId: uuid() });
     },
     addCardBack: (state) => {
-      state.postDetail.cards.push({ ...initCard });
+      state.postDetail.cards.push({ ...initCard, cardId: uuid() });
     },
     addHashTags: (state, action: PayloadAction<string>) => {
       state.postDetail.hashtags.push(action.payload);

--- a/src/utils/card/validateCardDetails.ts
+++ b/src/utils/card/validateCardDetails.ts
@@ -1,0 +1,30 @@
+import INewCard from "interface/card/INewCard";
+import { toast } from "react-toastify";
+
+export const validateCardDetails = (card: INewCard) => {
+  if (!card.image) {
+    toast.error(`이미지는 필수항목입니다.`);
+    return false;
+  }
+  if (!card.latitude || !card.location || !card.longitude) {
+    toast.error(`위치정보는 필수항목입니다.`);
+    return false;
+  }
+  console.log("통과");
+  return true;
+};
+
+export const validateCardList = (cardList: INewCard[]): boolean => {
+  for (let i = 0; i < cardList.length; i++) {
+    const card = cardList[i];
+    if (!card.image) {
+      toast.error(`${i}번째 이미지가 누락되었습니다.`);
+      return false;
+    }
+    if (!card.latitude || !card.location || !card.longitude) {
+      toast.error(`${i}번째 위치정보가 누락되었습니다.`);
+      return false;
+    }
+  }
+  return true;
+};


### PR DESCRIPTION
# 새로운 포스트 모달 구현 완료

## Stepper 커스텀 스타일 적용

기본 stepper가 파랑색인 부분과 세부적인 스타일 수정을 통해서 ui 수정을 마쳤습니다.

<img width="728" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/734705cf-faf8-4e94-80e8-442470ba4ee9">

## 단일 카드 삭제 기능 구현
단일 카드 폼에서 이미지에 커서를 올리는 경우 이미지를 삭제시킬 수 있는 아이콘이 뜹니다. 이를 통해 카드 이미지를 삭제하고 다시 생성할 수 있습니다.

<img width="363" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/07a137dc-a317-4872-a4fe-39eae08b495d">

## 검증 추가
각 카드들에 대한 검증과 스텝을 넘어가는 경우, 업로드 되는 경우에 각각 적절한 검증을 구현했습니다. 
utils/card 에 단일 카드 검증과 카드리스트 검증 로직을 구현했습니다.
포스트 버튼을 누르는 경우에 리덕스에 있는 포스트 타이틀이 설정되었는지 확인하고 아닌 경우 경고창을 toast로 출력합니다.

### 포스트 상세로 가기전 검증

<img width="1128" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/3f59cd29-9d52-49c0-b582-022e21619474">

### 다른 카드 만들기 전 검증

<img width="1154" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/95e37455-0d71-44c4-95ad-103a457e5220">

## 업로드 전 검증
<img width="1121" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/927bf636-ce07-4754-bd2b-0b02afc193e0">


## 포스트 상세 폼 구현
왼쪽에는 카드들을 리스트 형식으로 보여줍니다. 오른쪽에는 상세 내용이 들어갑니다.

## 기본 구조
<img width="737" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/3dec70b7-145d-4042-a6cc-85f6ce7bbe05">

## 카드리스트 오버레이
각각의 카드들에 오버레이를 적용해서 카드를 삭제할 수 있는 아이콘과 인덱스 번호를 렌더링합니다.
<img width="300" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/b3f67c83-fbdf-469f-bc63-25d2c3cfb812">

## 포스트 api
포스트 api를 통해 새로운 포스트를 등록합니다.
<img width="771" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/38905dc3-2fcf-4939-b262-3eaab4278abd">

## 썸네일 설정
리스트에서 클릭하는 경우 썸네일이 지정되면서 테두리가 생기게 됩니다.
<img width="715" alt="image" src="https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/c0a6c420-36bf-479c-954f-d35a3ec9b53b">



