### PR TITLE
Feat : PO-98 다른 유저 프로필 보기 기능 추가

### DIFF
--- a/src/api/follow/postFollowMember.ts
+++ b/src/api/follow/postFollowMember.ts
@@ -2,7 +2,8 @@ import { axiosInstance } from "api/token/axiosInstance";
 import { toast } from "react-toastify";
 
 const postFollowMember = async (
-  followingMemberId: number
+  followingMemberId: number,
+  type: string
 ): Promise<boolean> => {
   try {
     const API_URL = `/api/member/my/follow/${followingMemberId}`;
@@ -10,8 +11,11 @@ const postFollowMember = async (
     const response = await axiosInstance.post(API_URL);
 
     const { status } = response;
+    console.log(response.data);
     if (status === 200) {
-      toast.info("팔로우 완료");
+      type === "팔로우"
+        ? toast.info(`${type} 완료`)
+        : toast.error(`${type} 완료`);
       return true;
     }
     return false;

--- a/src/api/member/getOtherMemberInfo.ts
+++ b/src/api/member/getOtherMemberInfo.ts
@@ -1,0 +1,22 @@
+import { axiosInstance } from "api/token/axiosInstance";
+import { IOtherMemberInfo } from "interface/member/IOtherMemberInfo";
+
+const getOtherMemberInfo = async (
+  memberId: number
+): Promise<IOtherMemberInfo | null> => {
+  try {
+    const API_URI = `/api/member/profile?memberId=${memberId}`;
+
+    const response = await axiosInstance.get(API_URI);
+    const { status, data } = response;
+    if (status === 200) {
+      return data as IOtherMemberInfo;
+    } else {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+};
+
+export default getOtherMemberInfo;

--- a/src/components/card/postDetail/thumbnailCard/ThumbnailCard.module.css
+++ b/src/components/card/postDetail/thumbnailCard/ThumbnailCard.module.css
@@ -29,6 +29,12 @@
   font-weight: bold;
 }
 
+.updateTime {
+  margin-left: 10px;
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
 .thumbnailCard .actionControl {
   display: flex;
   flex-direction: row;

--- a/src/components/card/postDetail/thumbnailCard/ThumbnailCard.tsx
+++ b/src/components/card/postDetail/thumbnailCard/ThumbnailCard.tsx
@@ -12,6 +12,7 @@ import { toast } from "react-toastify";
 
 interface ThumbnailCardProps {
   memberId: number;
+  postUpdatedTime: string;
   postId: number;
   title: string;
   goodNumber: number;
@@ -22,8 +23,18 @@ interface ThumbnailCardProps {
   memberGood: boolean;
 }
 
+const formattedDate = (date: string) => {
+  const updatedDate = new Date(date);
+  return updatedDate.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+};
+
 function ThumbnailCard({
   memberId,
+  postUpdatedTime,
   postId,
   title,
   goodNumber,
@@ -72,7 +83,12 @@ function ThumbnailCard({
     <article className={cardStyles.thumbnailCard}>
       {imageUrl && <img src={imageUrl} alt="썸네일" />}
       <div className={cardStyles.header}>
-        <div className={cardStyles.title}>{title}</div>
+        <div className={cardStyles.title}>
+          <span>{title}</span>
+          <span className={cardStyles.updateTime}>
+            {formattedDate(postUpdatedTime)}
+          </span>
+        </div>
         <div className={cardStyles.actionControl}>
           <MdBookmarkAdd size={"24px"} onClick={handleAddPostWishList} />
           <div onClick={() => handleHeartClick()}>

--- a/src/components/form/card/CardForm.tsx
+++ b/src/components/form/card/CardForm.tsx
@@ -110,7 +110,7 @@ function CardForm({ cardIndex, cardDetails }: CardFormProps) {
       {!newCard.image ? (
         <div className={formStyles.imageWrapper}>
           <img
-            src="./icons/photo/postPhoto.png"
+            src="/icons/photo/postPhoto.png"
             width="100px"
             alt="Placeholder for upload"
           />

--- a/src/components/form/post/NewPostDetails.module.css
+++ b/src/components/form/post/NewPostDetails.module.css
@@ -6,6 +6,21 @@
   flex-direction: row;
 }
 
+.gridContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.gridLabel {
+  width: 100%;
+  text-align: center;
+  font-size: 1.2rem;
+  padding: 10px 4px;
+  font-weight: bold;
+}
+
 .container {
   padding: 20px;
   font-family: "Arial", sans-serif;

--- a/src/components/form/post/NewPostDetails.tsx
+++ b/src/components/form/post/NewPostDetails.tsx
@@ -41,7 +41,10 @@ function NewPostDetails() {
   };
   return (
     <div className={formStyles.postDetailWrapper}>
-      <CardGrid cards={cardList} />
+      <div className={formStyles.gridContainer}>
+        <span className={formStyles.gridLabel}>썸네일 카드를 선택해주세요</span>
+        <CardGrid cards={cardList} />
+      </div>
       <div className={formStyles.inputContainer}>
         <input
           id="title"

--- a/src/components/grid/userPhotoGallery/wishListPost/WishListPostGrid.tsx
+++ b/src/components/grid/userPhotoGallery/wishListPost/WishListPostGrid.tsx
@@ -28,6 +28,16 @@ const WishListPostGrid = ({
       setWishlistPosts((prev) => [...prev, ...data.posts]);
     }
   };
+
+  // 위시리스트 ID가 변경되었을 때 포스트 목록 초기화
+  useEffect(() => {
+    setWishlistPosts([]);
+    setPage(1);
+    setHasNext(true);
+    fetchWishList(); // 새 ID에 대한 데이터 바로 로드
+    // eslint-disable-next-line
+  }, [wishListId]);
+
   useEffect(
     () => {
       fetchWishList();

--- a/src/components/header/cardLIst/CardLIstHeader.tsx
+++ b/src/components/header/cardLIst/CardLIstHeader.tsx
@@ -34,17 +34,21 @@ function CardListHeader({ memberInfo, postId }: CarsListHeaderProps) {
     });
   };
 
+  const handleShowMemberInfo = () => {
+    openModal(ModalOption.OTHER_MEMBER_INFO, { memberId: memberInfo.memberId });
+  };
+
   return (
     <div className={headerStyles.header}>
       <div className={headerStyles.profile}>
-        <div className={headerStyles.profileImg}>
+        <div className={headerStyles.profileImg} onClick={handleShowMemberInfo}>
           {profileImg ? (
             <img src={profileImg} alt="유저 이미지" />
           ) : (
             <img src="/basic/profile.png" alt="default profile" />
           )}
         </div>
-        <span>{memberInfo.nickname}</span>
+        <span onClick={handleShowMemberInfo}>{memberInfo.nickname}</span>
       </div>
       <IoIosMore
         size={"24px"}

--- a/src/components/header/cardLIst/CardListHeader.module.css
+++ b/src/components/header/cardLIst/CardListHeader.module.css
@@ -15,9 +15,11 @@
 .profile span {
   font-size: 1.4rem;
   font-weight: bold;
+  cursor: pointer;
 }
 
 .profileImg {
+  cursor: pointer;
   width: 24px;
   height: 24px;
   overflow: hidden;

--- a/src/components/modal/member/miniProfile/MiniProfileModal.module.css
+++ b/src/components/modal/member/miniProfile/MiniProfileModal.module.css
@@ -1,0 +1,28 @@
+.previewBackdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1002;
+}
+
+.previewModal {
+  padding: 20px;
+  background-color: #fff;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+}
+
+.closeButton {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}

--- a/src/components/modal/member/miniProfile/MiniProfileModal.tsx
+++ b/src/components/modal/member/miniProfile/MiniProfileModal.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import getOtherMemberInfo from "api/member/getOtherMemberInfo";
 import { IOtherMemberInfo } from "interface/member/IOtherMemberInfo";
 import { useModal } from "hooks/modal/ModalProvider";
-import useBucket from "hooks/bucket/useBucket";
 import ModalOption from "enum/modalOptionTypes";
 import { IoMdClose } from "react-icons/io";
 
@@ -14,7 +13,6 @@ interface MiniProfileModalProps {
 
 const MiniProfileModal = ({ memberId }: MiniProfileModalProps) => {
   const { closeModal } = useModal();
-  const { getImage } = useBucket();
   const [memberInfo, setMemberInfo] = useState<IOtherMemberInfo>();
   useEffect(
     () => {
@@ -39,7 +37,9 @@ const MiniProfileModal = ({ memberId }: MiniProfileModalProps) => {
         onClick={(e) => e.stopPropagation()}
       >
         <IoMdClose size={"24px"} className={modalStyles.closeButton} />
-        {memberInfo && <MiniProfile memberInfo={memberInfo} />}
+        {memberInfo && memberId && (
+          <MiniProfile memberInfo={memberInfo} memberId={memberId} />
+        )}
       </div>
     </div>
   );

--- a/src/components/modal/member/miniProfile/MiniProfileModal.tsx
+++ b/src/components/modal/member/miniProfile/MiniProfileModal.tsx
@@ -1,0 +1,48 @@
+import MiniProfile from "containers/miniProfile/MiniProfile";
+import modalStyles from "./MiniProfileModal.module.css";
+import { useEffect, useState } from "react";
+import getOtherMemberInfo from "api/member/getOtherMemberInfo";
+import { IOtherMemberInfo } from "interface/member/IOtherMemberInfo";
+import { useModal } from "hooks/modal/ModalProvider";
+import useBucket from "hooks/bucket/useBucket";
+import ModalOption from "enum/modalOptionTypes";
+import { IoMdClose } from "react-icons/io";
+
+interface MiniProfileModalProps {
+  memberId?: number;
+}
+
+const MiniProfileModal = ({ memberId }: MiniProfileModalProps) => {
+  const { closeModal } = useModal();
+  const { getImage } = useBucket();
+  const [memberInfo, setMemberInfo] = useState<IOtherMemberInfo>();
+  useEffect(
+    () => {
+      if (!memberId) return;
+      const fetchMemberInfo = async () => {
+        const data = await getOtherMemberInfo(memberId);
+        if (data) setMemberInfo(data);
+      };
+      fetchMemberInfo();
+    },
+    //eslint-disable-next-line
+    []
+  );
+
+  const handleCloseModal = () => {
+    closeModal(ModalOption.OTHER_MEMBER_INFO);
+  };
+  return (
+    <div className={modalStyles.previewBackdrop} onClick={handleCloseModal}>
+      <div
+        className={modalStyles.previewModal}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <IoMdClose size={"24px"} className={modalStyles.closeButton} />
+        {memberInfo && <MiniProfile memberInfo={memberInfo} />}
+      </div>
+    </div>
+  );
+};
+
+export default MiniProfileModal;

--- a/src/components/modal/option/PostOptionModal.tsx
+++ b/src/components/modal/option/PostOptionModal.tsx
@@ -23,7 +23,7 @@ const PostOptionModal = ({ memberId, postId }: PostOptionModalProps) => {
   };
 
   const handleFollow = async () => {
-    const result = await postFollowMember(memberId);
+    const result = await postFollowMember(memberId, "팔로우");
     if (result) closeModal(ModalOption.POST_OPTION);
   };
 

--- a/src/components/modal/option/PostOptionModal.tsx
+++ b/src/components/modal/option/PostOptionModal.tsx
@@ -49,6 +49,10 @@ const PostOptionModal = ({ memberId, postId }: PostOptionModalProps) => {
     openModal(ModalOption.DELETE_WARNING, { type: "post", targetId: postId });
   };
 
+  const handleOpenMiniProfile = () => {
+    openModal(ModalOption.OTHER_MEMBER_INFO, { memberId: memberId });
+  };
+
   return (
     <div className={modalStyles.backdrop} onClick={handleCancel}>
       <div
@@ -76,7 +80,9 @@ const PostOptionModal = ({ memberId, postId }: PostOptionModalProps) => {
         <button className={modalStyles.option} onClick={handleCopyLink}>
           링크 복사
         </button>
-        <button className={modalStyles.option}>계정 정보</button>
+        <button className={modalStyles.option} onClick={handleOpenMiniProfile}>
+          계정 정보
+        </button>
         <button className={modalStyles.option} onClick={handleCancel}>
           취소
         </button>

--- a/src/components/paging/card/CardPaging.module.css
+++ b/src/components/paging/card/CardPaging.module.css
@@ -19,6 +19,10 @@
   border: 0;
   cursor: pointer;
   margin: 10px 10px;
+  display: flex;
+  flex-direction: row;
+  gap: 3px;
+  align-items: center;
 }
 
 .backIcon {
@@ -26,4 +30,6 @@
   flex-direction: row;
   align-items: center;
   cursor: pointer;
+  font-size: 1.2rem;
+  text-align: center;
 }

--- a/src/components/paging/card/CardPaging.tsx
+++ b/src/components/paging/card/CardPaging.tsx
@@ -1,6 +1,7 @@
 import pagingStyles from "./CardPaging.module.css";
 import ArrowBackIosIcon from "@mui/icons-material/ArrowBackIos";
 import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
+import { IoMdAdd } from "react-icons/io";
 
 interface CardPagingProps {
   totalCardNum: number;
@@ -32,15 +33,21 @@ function CardPaging({
   return (
     <div className={pagingStyles.paging}>
       <span className={pagingStyles.backIcon} onClick={handleCardLeft}>
-        <ArrowBackIosIcon className={pagingStyles.btn} />
-        뒤로가기
+        <div className={pagingStyles.btn}>
+          <ArrowBackIosIcon />
+          {curCardIndex === 0 ? "카드 추가하기" : "이전 카드"}
+          {curCardIndex === 0 ? <IoMdAdd /> : ""}
+        </div>
       </span>
       <div className={pagingStyles.dots} style={{ textAlign: "center" }}>
         {dots}
       </div>
       <span className={pagingStyles.backIcon} onClick={handleCardRight}>
-        카드 추가하기
-        <ArrowForwardIosIcon className={pagingStyles.btn} />
+        <div className={pagingStyles.btn}>
+          {curCardIndex === totalCardNum - 1 ? "카드 추가하기" : "다음 카드"}
+          {curCardIndex === totalCardNum - 1 ? <IoMdAdd /> : ""}
+          <ArrowForwardIosIcon />
+        </div>
       </span>
     </div>
   );

--- a/src/containers/miniProfile/MiniProfile.module.css
+++ b/src/containers/miniProfile/MiniProfile.module.css
@@ -49,7 +49,7 @@
 
 .thumbnailGrid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr); /* 5개의 컬럼으로 고정 */
+  grid-template-columns: repeat(3, 1fr); /* 5개의 컬럼으로 고정 */
   gap: 4px;
 }
 

--- a/src/containers/miniProfile/MiniProfile.module.css
+++ b/src/containers/miniProfile/MiniProfile.module.css
@@ -4,8 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  border: 1px solid #d9d9d9;
-  padding: 70px 10px;
+  padding: 40px 10px;
 }
 
 .imgContainer {
@@ -46,4 +45,17 @@
   font-size: 1.4rem;
   font-weight: 800;
   margin-bottom: 10px;
+}
+
+.thumbnailGrid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr); /* 5개의 컬럼으로 고정 */
+  gap: 4px;
+}
+
+.thumbnailGrid img {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
 }

--- a/src/containers/miniProfile/MiniProfile.module.css
+++ b/src/containers/miniProfile/MiniProfile.module.css
@@ -1,0 +1,49 @@
+.card {
+  width: 400px;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid #d9d9d9;
+  padding: 70px 10px;
+}
+
+.imgContainer {
+  display: flex;
+  justify-content: center;
+}
+
+.header {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.header span {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.action {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+}
+
+.stat span {
+  font-size: 1.4rem;
+  font-weight: 500;
+}
+
+.username {
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin-bottom: 10px;
+}

--- a/src/containers/miniProfile/MiniProfile.module.css
+++ b/src/containers/miniProfile/MiniProfile.module.css
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 40px 10px;
+  padding: 10px 10px;
 }
 
 .imgContainer {
@@ -58,4 +58,47 @@
   height: auto;
   aspect-ratio: 1 / 1;
   object-fit: cover;
+}
+
+.followButton {
+  margin-top: 10px;
+  cursor: pointer;
+  background-color: var(--main-theme-color);
+  border-radius: 10px;
+  color: white;
+  transition: 0.2s all ease-in;
+  box-sizing: border-box;
+  border: 1px solid rgba(0, 0, 0, 0);
+}
+
+.followButton:hover {
+  background-color: white;
+  color: var(--main-theme-color);
+  border: 1px solid var(--main-theme-color);
+  box-sizing: border-box;
+}
+
+.followButton:focus {
+  outline: none;
+}
+
+.unFollowButton {
+  margin-top: 10px;
+  background-color: white;
+  color: tomato;
+  border-radius: 10px;
+  box-sizing: border-box;
+  transition: 0.2s all ease-in;
+  border: 1px solid rgba(0, 0, 0, 0);
+}
+
+.unFollowButton:hover {
+  background-color: tomato;
+  color: white;
+  border: 1px solid tomato;
+  box-sizing: border-box;
+}
+
+.unFollowButton:focus {
+  outline: none;
 }

--- a/src/containers/miniProfile/MiniProfile.tsx
+++ b/src/containers/miniProfile/MiniProfile.tsx
@@ -3,18 +3,21 @@ import ProfileImg from "../../components/user/ProfileImg";
 import profileStyles from "./MiniProfile.module.css";
 import useBucket from "hooks/bucket/useBucket";
 import { useEffect, useState } from "react";
-import { useModal } from "hooks/modal/ModalProvider";
 import { IOtherMemberInfo } from "interface/member/IOtherMemberInfo";
+import postFollowMember from "api/follow/postFollowMember";
+import secureLocalStorage from "react-secure-storage";
 
 interface MiniProfileProps {
   memberInfo: IOtherMemberInfo;
+  memberId: number;
 }
 
-function MiniProfile({ memberInfo }: MiniProfileProps) {
+function MiniProfile({ memberInfo, memberId }: MiniProfileProps) {
   const [profileImgURL, setProfileImgURL] = useState<string>("");
   const { getImage } = useBucket();
-  const { openModal } = useModal();
   const [thumbnailImages, setThumbNailImages] = useState<string[]>([]);
+  const [isFollowed, setIsFollowed] = useState<boolean>(false);
+  const hostMemberId = secureLocalStorage.getItem("member");
 
   useEffect(() => {
     const fetchProfileImg = async () => {
@@ -40,6 +43,18 @@ function MiniProfile({ memberInfo }: MiniProfileProps) {
     // eslint-disable-next-line
   }, []);
 
+  const postFollowing = async () => {
+    const data = await postFollowMember(
+      memberId,
+      isFollowed ? "언팔로우" : "팔로우"
+    );
+    if (data) setIsFollowed((prev) => !prev);
+  };
+
+  const handleFollowing = () => {
+    postFollowing();
+  };
+
   return (
     <div className={profileStyles.card}>
       <div className={profileStyles.imgContainer}>
@@ -59,6 +74,18 @@ function MiniProfile({ memberInfo }: MiniProfileProps) {
           <img src={thumbnail} alt="post 썸네일" key={index} />
         ))}
       </div>
+      {hostMemberId !== memberId && (
+        <button
+          className={
+            isFollowed
+              ? profileStyles.unFollowButton
+              : profileStyles.followButton
+          }
+          onClick={handleFollowing}
+        >
+          {isFollowed ? "언팔로우" : "팔로우"}
+        </button>
+      )}
     </div>
   );
 }

--- a/src/containers/miniProfile/MiniProfile.tsx
+++ b/src/containers/miniProfile/MiniProfile.tsx
@@ -14,6 +14,7 @@ function MiniProfile({ memberInfo }: MiniProfileProps) {
   const [profileImgURL, setProfileImgURL] = useState<string>("");
   const { getImage } = useBucket();
   const { openModal } = useModal();
+  const [thumbnailImages, setThumbNailImages] = useState<string[]>([]);
 
   useEffect(() => {
     const fetchProfileImg = async () => {
@@ -22,7 +23,20 @@ function MiniProfile({ memberInfo }: MiniProfileProps) {
         if (imgUrl) setProfileImgURL(imgUrl);
       }
     };
+    const fetchThumbnails = async () => {
+      if (memberInfo.thumbnails && memberInfo.thumbnails.length > 0) {
+        const thumbnailPromises = memberInfo.thumbnails.map((thumbnail) =>
+          getImage(thumbnail)
+        );
+        const thumbnails = await Promise.all(thumbnailPromises);
+        const validThumbnails = thumbnails.filter(
+          (url): url is string => url !== null
+        );
+        setThumbNailImages(validThumbnails);
+      }
+    };
     fetchProfileImg();
+    fetchThumbnails();
     // eslint-disable-next-line
   }, []);
 
@@ -40,6 +54,11 @@ function MiniProfile({ memberInfo }: MiniProfileProps) {
         <span>{`팔로우 ${memberInfo.followingNumber}`}</span>
       </div>
       <div className={profileStyles.username}>{memberInfo.name}</div>
+      <div className={profileStyles.thumbnailGrid}>
+        {thumbnailImages.map((thumbnail, index) => (
+          <img src={thumbnail} alt="post 썸네일" key={index} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/containers/miniProfile/MiniProfile.tsx
+++ b/src/containers/miniProfile/MiniProfile.tsx
@@ -1,0 +1,46 @@
+import ProfileImg from "../../components/user/ProfileImg";
+
+import profileStyles from "./MiniProfile.module.css";
+import useBucket from "hooks/bucket/useBucket";
+import { useEffect, useState } from "react";
+import { useModal } from "hooks/modal/ModalProvider";
+import { IOtherMemberInfo } from "interface/member/IOtherMemberInfo";
+
+interface MiniProfileProps {
+  memberInfo: IOtherMemberInfo;
+}
+
+function MiniProfile({ memberInfo }: MiniProfileProps) {
+  const [profileImgURL, setProfileImgURL] = useState<string>("");
+  const { getImage } = useBucket();
+  const { openModal } = useModal();
+
+  useEffect(() => {
+    const fetchProfileImg = async () => {
+      if (memberInfo.profileImage) {
+        const imgUrl = await getImage(memberInfo.profileImage);
+        if (imgUrl) setProfileImgURL(imgUrl);
+      }
+    };
+    fetchProfileImg();
+    // eslint-disable-next-line
+  }, []);
+
+  return (
+    <div className={profileStyles.card}>
+      <div className={profileStyles.imgContainer}>
+        <ProfileImg size={"200px"} imgUrl={profileImgURL} onClick={() => {}} />
+      </div>
+      <div className={profileStyles.header}>
+        <span>{memberInfo.nickname}</span>
+      </div>
+      <div className={profileStyles.stat}>
+        <span>{`게시물 ${memberInfo.postNumber}`}</span>
+        <span>{`팔로워 ${memberInfo.followedNumber}`}</span>
+        <span>{`팔로우 ${memberInfo.followingNumber}`}</span>
+      </div>
+      <div className={profileStyles.username}>{memberInfo.name}</div>
+    </div>
+  );
+}
+export default MiniProfile;

--- a/src/containers/myPage/MyPageContainer.module.css
+++ b/src/containers/myPage/MyPageContainer.module.css
@@ -14,6 +14,10 @@
   max-width: 600px;
 }
 
+.profileCard {
+  border: 1px solid #ccc;
+}
+
 .userHistoryWrapper {
   flex-grow: 1;
   height: calc(100vh - 75px);

--- a/src/containers/myPage/MyPageContainer.tsx
+++ b/src/containers/myPage/MyPageContainer.tsx
@@ -21,7 +21,9 @@ function MyPageContainer() {
   return (
     <div className={containerStyle.wrapper}>
       <div className={containerStyle.profileWrapper}>
-        <ProfileCard memberInfo={memberInfo} />
+        <div className={containerStyle.profileCard}>
+          <ProfileCard memberInfo={memberInfo} />
+        </div>
       </div>
       <div className={containerStyle.userHistoryWrapper}>
         <UserHistoryContainer memberId={memberInfo.memberId} />

--- a/src/containers/post/postCardList/mobile/CarouselPostCardsList.tsx
+++ b/src/containers/post/postCardList/mobile/CarouselPostCardsList.tsx
@@ -21,6 +21,7 @@ function CarouselPostCardsList({
   const cards = [
     <ThumbnailCard
       memberId={postDetails.memberInfo.memberId}
+      postUpdatedTime={postDetails.updatedTime}
       postId={postId}
       key="thumbnail"
       title={postDetails.title}

--- a/src/containers/post/postCardList/web/PostCardLIstCarousel.tsx
+++ b/src/containers/post/postCardList/web/PostCardLIstCarousel.tsx
@@ -48,6 +48,7 @@ const PostCardListCarousel = ({
   const cards = [
     <ThumbnailCard
       memberId={postDetails.memberInfo.memberId}
+      postUpdatedTime={postDetails.updatedTime}
       postId={postId}
       title={postDetails.title}
       goodNumber={postDetails.goodNumber}

--- a/src/containers/post/postCardList/web/PostCardList.tsx
+++ b/src/containers/post/postCardList/web/PostCardList.tsx
@@ -12,6 +12,7 @@ interface PostCardListProps {
 function PostCardList({ postDetails, postId }: PostCardListProps) {
   const cards = [
     <ThumbnailCard
+      postUpdatedTime={postDetails.updatedTime}
       memberId={postDetails.memberInfo.memberId}
       postId={postId}
       title={postDetails.title}

--- a/src/containers/profile/ProfileCard.module.css
+++ b/src/containers/profile/ProfileCard.module.css
@@ -4,7 +4,6 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  border: 1px solid #d9d9d9;
   padding: 70px 10px;
 }
 

--- a/src/enum/modalOptionTypes.ts
+++ b/src/enum/modalOptionTypes.ts
@@ -17,6 +17,7 @@ enum ModalOption {
   SHARE = "SHARE",
   USER_SETTING = "USER_SETTING",
   USER_INFO = "USER_INFO",
+  OTHER_MEMBER_INFO = "OTHER_MEMBER_INFO",
 }
 
 export default ModalOption;

--- a/src/interface/member/IOtherMemberInfo.ts
+++ b/src/interface/member/IOtherMemberInfo.ts
@@ -1,0 +1,9 @@
+export interface IOtherMemberInfo {
+  name: string;
+  nickname: string;
+  profileImage: string;
+  postNumber: number;
+  followedNumber: number;
+  followingNumber: number;
+  thumbnails: string[];
+}

--- a/src/interface/post/IPostDTO.ts
+++ b/src/interface/post/IPostDTO.ts
@@ -12,6 +12,7 @@ export interface IPostDTO {
   concept: conceptOptionType;
   region: regionOptionType;
   cards: INewCard[];
+  updatedTime: string;
   postHashtags: { hashTagId: number; tagName: string }[];
   memberGood: boolean;
 }

--- a/src/routes/MyPage.tsx
+++ b/src/routes/MyPage.tsx
@@ -23,6 +23,7 @@ import { toast } from "react-toastify";
 import DeleteWarningModal from "components/modal/warn/deleteWarning/DeleteWarningModal";
 import AddPostWishList from "components/modal/wish/addPostWishList/AddPostWishList";
 import getMemberInfo from "api/member/getMemberInfo";
+import MiniProfileModal from "components/modal/member/miniProfile/MiniProfileModal";
 
 function MyPage() {
   const { registerModal, closeModal } = useModal();
@@ -41,6 +42,7 @@ function MyPage() {
     registerModal(ModalOption.DELETE_WARNING, <DeleteWarningModal />);
     registerModal(ModalOption.ALBUM_EDIT, <EditAlbumModal />);
     registerModal(ModalOption.ADD_TO_WISH, <AddPostWishList />);
+    registerModal(ModalOption.OTHER_MEMBER_INFO, <MiniProfileModal />);
     return () => {
       closeModal(ModalOption.POST);
       closeModal(ModalOption.WARNING);
@@ -56,6 +58,7 @@ function MyPage() {
       closeModal(ModalOption.DELETE_WARNING);
       closeModal(ModalOption.ALBUM_EDIT);
       closeModal(ModalOption.ADD_TO_WISH);
+      closeModal(ModalOption.OTHER_MEMBER_INFO);
     };
     // eslint-disable-next-line
   }, []);

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -1,5 +1,6 @@
 import getMemberInfo from "api/member/getMemberInfo";
 import Header from "components/header/web/WebHeader";
+import MiniProfileModal from "components/modal/member/miniProfile/MiniProfileModal";
 import PostOptionModal from "components/modal/option/PostOptionModal";
 import ShareModal from "components/modal/shareModal/ShareModal";
 import DeleteWarningModal from "components/modal/warn/deleteWarning/DeleteWarningModal";
@@ -18,11 +19,13 @@ function Post() {
       registerModal(ModalOption.SHARE, <ShareModal />);
       registerModal(ModalOption.ADD_TO_WISH, <AddPostWishList />);
       registerModal(ModalOption.DELETE_WARNING, <DeleteWarningModal />);
+      registerModal(ModalOption.OTHER_MEMBER_INFO, <MiniProfileModal />);
       return () => {
         closeModal(ModalOption.POST_OPTION);
         closeModal(ModalOption.SHARE);
         closeModal(ModalOption.ADD_TO_WISH);
         closeModal(ModalOption.DELETE_WARNING);
+        closeModal(ModalOption.OTHER_MEMBER_INFO);
       };
     },
     //eslint-disable-next-line

--- a/src/routes/Post.tsx
+++ b/src/routes/Post.tsx
@@ -1,9 +1,11 @@
 import getMemberInfo from "api/member/getMemberInfo";
 import Header from "components/header/web/WebHeader";
 import MiniProfileModal from "components/modal/member/miniProfile/MiniProfileModal";
+import NewPostModal from "components/modal/newPost/NewPostModal";
 import PostOptionModal from "components/modal/option/PostOptionModal";
 import ShareModal from "components/modal/shareModal/ShareModal";
 import DeleteWarningModal from "components/modal/warn/deleteWarning/DeleteWarningModal";
+import WarningModal from "components/modal/warn/WarningModal";
 import AddPostWishList from "components/modal/wish/addPostWishList/AddPostWishList";
 import PostDetail from "containers/post/PostDetails";
 import ModalOption from "enum/modalOptionTypes";
@@ -16,11 +18,16 @@ function Post() {
   useEffect(
     () => {
       registerModal(ModalOption.POST_OPTION, <PostOptionModal />);
+      registerModal(ModalOption.WARNING, <WarningModal />);
       registerModal(ModalOption.SHARE, <ShareModal />);
       registerModal(ModalOption.ADD_TO_WISH, <AddPostWishList />);
       registerModal(ModalOption.DELETE_WARNING, <DeleteWarningModal />);
       registerModal(ModalOption.OTHER_MEMBER_INFO, <MiniProfileModal />);
+      registerModal(ModalOption.POST, <NewPostModal />);
+
       return () => {
+        closeModal(ModalOption.POST);
+        closeModal(ModalOption.WARNING);
         closeModal(ModalOption.POST_OPTION);
         closeModal(ModalOption.SHARE);
         closeModal(ModalOption.ADD_TO_WISH);

--- a/src/utils/card/validateCardDetails.ts
+++ b/src/utils/card/validateCardDetails.ts
@@ -18,10 +18,10 @@ export const validateCardList = (cardList: INewCard[]): boolean => {
   for (let i = 0; i < cardList.length; i++) {
     const card = cardList[i];
     if (!card.image) {
-      toast.error(`${i}번째 이미지가 누락되었습니다.`);
-      return false;
-    }
-    if (!card.latitude || !card.location || !card.longitude) {
+      toast.error(
+        `${i + 1}번째 이미지가 누락되었습니다. 해당 카드는 삭제됩니다.`
+      );
+    } else if (!card.latitude || !card.location || !card.longitude) {
       toast.error(`${i}번째 위치정보가 누락되었습니다.`);
       return false;
     }


### PR DESCRIPTION
# 다른 유저 프로필 보기 기능 추가
## 기능
### 프로필 보기 기능
- 포스트 해더에 있는 이미지나 이름을 클릭하는 경우에 프로필 정보를 볼 수 있습니다.
- 프로필 정보를 보고 유저를 팔로우 할 수 있도록 수정했습니다.

### 새 포스트 모달
- 카드 리스트 페이징 기능에서 표현이 모호한 부분은 수정했습니다.
- 카드리스트 검증 로직에서 카드 이미지는 제외시키고 없는 경우 삭제 시키도록 했습니다.

## 이미지
### 프로필 보기 기능
![image](https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/1c1186ac-0a17-46c8-aab9-c2facdf6b7ae)
![image](https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/e5df2ba0-89e7-40a0-b6aa-f6d143eb1151)

### 새포스트 모달 
![image](https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/ce371f68-f794-4304-9bf2-f1bbeb6ca141)
![image](https://github.com/java-is-coffee/Front-PolaRoad/assets/62227770/daa59641-72df-43e3-a8a7-f6725cc5e65e)
