### PR TITLE
Feat : PO-13 로그인 화면 비밀번호 재설정 구현

### DIFF
--- a/src/api/login/postRestPassword.ts
+++ b/src/api/login/postRestPassword.ts
@@ -1,0 +1,25 @@
+import { axiosInstance } from "api/token/axiosInstance";
+export interface ResetPasswordData {
+  email: string;
+  name: string;
+}
+
+export interface ResetPasswordDTO {
+  data: ResetPasswordData;
+}
+
+const postResetPassword = async (inputData: ResetPasswordDTO) => {
+  try {
+    const API_URL = "/api/member/login/reset-password";
+
+    const response = await axiosInstance.post(API_URL, inputData);
+
+    const code = response.status;
+
+    return code;
+  } catch (error) {
+    return null;
+  }
+};
+
+export default postResetPassword;

--- a/src/components/login/LoginComponent.tsx
+++ b/src/components/login/LoginComponent.tsx
@@ -36,8 +36,10 @@ const InputTextField = styled(TextField)({
 
 function LoginContainer({
   setOnRegister,
+  setOnResetPassword,
 }: {
   setOnRegister: React.Dispatch<React.SetStateAction<boolean>>;
+  setOnResetPassword: React.Dispatch<React.SetStateAction<boolean>>;
 }) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -137,6 +139,19 @@ function LoginContainer({
             계정이 없으신가요?
             <span style={{ color: "#13c4a3", marginLeft: "5PX" }}>
               가입하기
+            </span>
+          </Button>
+        </div>
+        <div className={styles.center}>
+          <Button
+            className={styles.bottomButton}
+            variant="outlined"
+            fullWidth
+            onClick={() => setOnResetPassword(true)}
+          >
+            비밀번호를 잊으셨나요?
+            <span style={{ color: "#13c4a3", marginLeft: "5PX" }}>
+              비밀번호 찾기
             </span>
           </Button>
         </div>

--- a/src/components/login/ResetPassword.tsx
+++ b/src/components/login/ResetPassword.tsx
@@ -109,6 +109,18 @@ function ResetPasswordContainer({
             >
               비밀번호 변경
             </Button>
+            <div className={styles.center}>
+              <Button
+                className={styles.bottomButton}
+                variant="outlined"
+                fullWidth
+                onClick={() => setOnResetPassword(false)}
+              >
+                <span style={{ color: "#13c4a3", marginLeft: "5PX" }}>
+                  로그인화면으로 돌아가기
+                </span>
+              </Button>
+            </div>
           </Stack>
         </form>
       </Stack>

--- a/src/components/login/ResetPassword.tsx
+++ b/src/components/login/ResetPassword.tsx
@@ -1,0 +1,119 @@
+import { Button, Stack, TextField, styled } from "@mui/material";
+import React, { useState } from "react";
+import styles from "./Login.module.css";
+import postResetPassword, {
+  ResetPasswordDTO,
+} from "api/login/postRestPassword";
+import { toast } from "react-toastify";
+
+const InputTextField = styled(TextField)({
+  fontSize: "1.5rem",
+  backgroundColor: "#F5F5F5",
+  borderRadius: "2px",
+  "& label": {
+    color: "#13c4a3",
+    fontSize: "1.3rem",
+  },
+  "& label.Mui-focused": {
+    color: "#13c4a3",
+  },
+
+  "& .MuiOutlinedInput-root": {
+    fontSize: "1.5rem",
+    "& fieldset": {
+      borderColor: "#13c4a3",
+    },
+  },
+
+  "& .MuiOutlinedInput-focused": {
+    fontSize: "1.5rem",
+    "& fieldset": {
+      borderColor: "#13c4a3",
+    },
+  },
+});
+
+function ResetPasswordContainer({
+  setOnResetPassword,
+}: {
+  setOnResetPassword: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+
+  //한번만 전송되어야 하기 때문에.
+  const [isSend, setIsSend] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const inputData: ResetPasswordDTO = {
+      data: {
+        email: email,
+        name: name,
+      },
+    };
+    setIsSend(true);
+
+    const result = await postResetPassword(inputData);
+    if (result === 200) {
+      toast.success("임시 비밀번호를 이메일로 발송했습니다. 확인해주세요.");
+      setOnResetPassword(false);
+    } else {
+      toast.error("입력해주신 정보들을 확인해주세요.");
+      setIsSend(false);
+    }
+  };
+
+  return (
+    <div>
+      <Stack className={styles.inputContainer} spacing={2}>
+        <form method="post" onSubmit={handleSubmit}>
+          <Stack spacing={2}>
+            <div>
+              <InputTextField
+                label="이메일 입력"
+                required
+                variant="outlined"
+                type="email"
+                size="small"
+                onChange={(value: React.ChangeEvent<HTMLInputElement>) => {
+                  setEmail(value.target.value);
+                }}
+                fullWidth
+                color="success"
+                autoComplete="off"
+              />
+            </div>
+            <InputTextField
+              size="small"
+              label="성명"
+              required
+              variant="outlined"
+              autoComplete="off"
+              onChange={(value: React.ChangeEvent<HTMLInputElement>) => {
+                setName(value.target.value);
+              }}
+              color="success"
+            />
+
+            <Button
+              variant="contained"
+              type="submit"
+              sx={{
+                backgroundColor: "#13c4a3",
+                fontSize: "1.5rem",
+                ":hover": { backgroundColor: "#13c4a3", fontSize: "1.5rem" },
+              }}
+              disabled={isSend ? true : false}
+            >
+              비밀번호 변경
+            </Button>
+          </Stack>
+        </form>
+      </Stack>
+    </div>
+  );
+}
+
+export default ResetPasswordContainer;

--- a/src/containers/login/LoginContainer.tsx
+++ b/src/containers/login/LoginContainer.tsx
@@ -2,9 +2,11 @@ import React, { useState } from "react";
 import styles from "../../components/login/Login.module.css";
 import LoginComponent from "../../components/login/LoginComponent";
 import RegisterComponent from "../../components/login/RegisterComponent";
+import ResetPasswordContainer from "components/login/ResetPassword";
 
 function LoginContainer() {
   const [onRegister, setOnRegister] = useState(false);
+  const [onResetPassword, setOnResetPassword] = useState(false);
 
   return (
     <div className={styles.loginContainer}>
@@ -17,8 +19,13 @@ function LoginContainer() {
       </div>
       {onRegister ? (
         <RegisterComponent setOnRegister={setOnRegister} />
+      ) : onResetPassword ? (
+        <ResetPasswordContainer setOnResetPassword={setOnResetPassword} />
       ) : (
-        <LoginComponent setOnRegister={setOnRegister} />
+        <LoginComponent
+          setOnRegister={setOnRegister}
+          setOnResetPassword={setOnResetPassword}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
# 기능
- 로그인 화면 비밀번호 재설정 화면 & 기능 구현
- 이메일 & 이름 입력 시, 이메일 전송 가능
- 이메일 전송 성공 시, 전송이 막히며 1번만 전송하도록 구현
- 이메일 전송 실패 시, 전송이 다시 열리며 다시 시도할 수 있도록 구현
- 이메일에 임시 비밀번호를 발급. 이후 로그인 화면으로 돌아오도록 구현

# 이미지
![image](https://github.com/java-is-coffee/Front-PolaRoad/assets/81568105/fadad2bb-4f95-4348-ab9e-63ac6c4b2e85)

